### PR TITLE
Fix Missing Space on Title Page

### DIFF
--- a/header.tex
+++ b/header.tex
@@ -96,7 +96,7 @@
       \end{minipage}
       \vspace{1cm}
 
-      \textsc{\thethesistype Thesis}\\[0.3cm]
+      \textsc{\thethesistype~Thesis}\\[0.3cm]
       % Title
       \HRule \\[0.4cm]
       { \Huge \scshape \thetitle \\[0.4cm] }


### PR DESCRIPTION
A space immedately after a macro is lex'ed away. Therefore the Title Page would state that this is a "Bachelor'sThesis" instead of a "Bachelor's Thesis", eliding the space, which looks wrong.